### PR TITLE
bulk send events/identify. better test coverage

### DIFF
--- a/src/Amplitude.Net.Tests/Amplitude.Net.Tests.csproj
+++ b/src/Amplitude.Net.Tests/Amplitude.Net.Tests.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Bogus" Version="34.0.2" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />

--- a/src/Amplitude.Net.Tests/BasicTests.cs
+++ b/src/Amplitude.Net.Tests/BasicTests.cs
@@ -1,7 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
+using Bogus;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -30,11 +34,12 @@ public class BasicTests
     [Fact]
     public async Task AssertIdentifyRequestSent()
     {
-        var httpClient = new HttpClient();
+        var counters = new Counters();
+        var httpClient = new HttpClient(new MockHttpMessageHandler(counters));
         var httpFactory = Substitute.For<IHttpClientFactory>();
         httpFactory.CreateClient().Returns(_ => httpClient);
 
-        var sender = new AsyncAmplitudeSender(httpFactory, _optionsWrapper);
+        var sender = new AsyncAmplitudeSender(httpFactory, _optionsWrapper, Substitute.For<ILogger<AsyncAmplitudeSender>>());
         var amplitude = new Amplitude(Substitute.For<ILogger<Amplitude>>(), sender);
 
         var userId = Guid.NewGuid().ToString("N");
@@ -46,7 +51,88 @@ public class BasicTests
 
         await Task.Delay(TimeSpan.FromMilliseconds(1000));
         
-        httpFactory.Received().CreateClient();
+        counters.Calls.ShouldBe(1);
+        counters.Successes.ShouldBe(1);
+    }
+    
+    [Fact]
+    public async Task AssertEventRequestSent()
+    {
+        var counters = new Counters();
+        var httpClient = new HttpClient(new MockHttpMessageHandler(counters));
+        var httpFactory = Substitute.For<IHttpClientFactory>();
+        httpFactory.CreateClient().Returns(_ => httpClient);
+
+        var sender = new AsyncAmplitudeSender(httpFactory, _optionsWrapper, Substitute.For<ILogger<AsyncAmplitudeSender>>());
+        var amplitude = new Amplitude(Substitute.For<ILogger<Amplitude>>(), sender);
+
+        var userId = Guid.NewGuid().ToString("N");
+        await amplitude.ForUserId(userId)
+            .Event("touched_sky", DateTime.UtcNow, new Dictionary<string, object>
+            {
+                {"first_name", "Billy Bob"}
+            });
+
+        await Task.Delay(TimeSpan.FromMilliseconds(1000));
+        
+        counters.Calls.ShouldBe(1);
+        counters.Successes.ShouldBe(1);
+    }
+    
+    [Fact]
+    public async Task AssertEventRequestSentUnderLoad()
+    {
+        var counters = new Counters();
+        var httpFactory = Substitute.For<IHttpClientFactory>();
+        httpFactory.CreateClient().Returns(_ => new HttpClient(new MockHttpMessageHandler(counters)));
+
+        var sender = new AsyncAmplitudeSender(httpFactory, _optionsWrapper, Substitute.For<ILogger<AsyncAmplitudeSender>>());
+       
+        await Parallel.ForEachAsync(Enumerable.Range(0, 100), async (i, token) =>
+        {
+            var amplitude = new Amplitude(Substitute.For<ILogger<Amplitude>>(), sender);
+            var faker = new Faker();
+            var userId = Guid.NewGuid().ToString("N");
+            await amplitude.ForUserId(userId)
+                .Event("touched_sky",  DateTime.UtcNow, new Dictionary<string, object>
+                {
+                    {"color", "blue"}
+                });
+        });
+
+        await Task.Delay(TimeSpan.FromMilliseconds(5000));
+        
+        counters.Calls.ShouldBe(5);
+        counters.Successes.ShouldBe(5);
+    }
+    
+    [Fact]
+    public async Task AssertIdentifyRequestSentUnderLoad()
+    {
+        var counters = new Counters();
+        var httpFactory = Substitute.For<IHttpClientFactory>();
+        httpFactory.CreateClient().Returns(_ => new HttpClient(new MockHttpMessageHandler(counters)));
+
+        var sender = new AsyncAmplitudeSender(httpFactory, _optionsWrapper, Substitute.For<ILogger<AsyncAmplitudeSender>>());
+
+        await Parallel.ForEachAsync(Enumerable.Range(0, 100), async (i, token) =>
+        {
+            var amplitude = new Amplitude(Substitute.For<ILogger<Amplitude>>(), sender);
+            var faker = new Faker();
+            var userId = Guid.NewGuid().ToString("N");
+            await amplitude.ForUserId(userId)
+                .Identify(new Dictionary<string, object>
+                {
+                    {"first_name", faker.Person.FirstName},
+                    {"last_name", faker.Person.LastName},
+                });
+        });
+
+        await Task.Delay(TimeSpan.FromMilliseconds(5000));
+        
+        //we have 100 requests and we deliver at most 20 per batch
+        counters.Calls.ShouldBe(5);
+        counters.Successes.ShouldBe(5);
     }
 
     [Fact]
@@ -58,5 +144,44 @@ public class BasicTests
         }
 
         Test();
+    }
+}
+
+public class Counters
+{
+    public int Calls;
+    public int Successes;
+}
+
+public class MockHttpMessageHandler : HttpClientHandler
+{
+    private readonly Counters _counters;
+    private Exception? _exception;
+
+    public MockHttpMessageHandler(Counters counters)
+    {
+        _counters = counters;
+    }
+
+    public Exception? Exception => _exception;
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        Interlocked.Increment(ref _counters.Calls);
+        try
+        {
+            var response = await base.SendAsync(request, cancellationToken);
+            if (response.IsSuccessStatusCode)
+            {
+                Interlocked.Increment(ref _counters.Successes);
+            }
+
+            return response;
+        }
+        catch (Exception ex)
+        {
+            _exception = ex;
+            throw;
+        }
     }
 }

--- a/src/Amplitude.Net.Tests/BasicTests.cs
+++ b/src/Amplitude.Net.Tests/BasicTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using System.Threading.Tasks;
 using Bogus;
 using Microsoft.Extensions.Configuration;
@@ -144,44 +143,5 @@ public class BasicTests
         }
 
         Test();
-    }
-}
-
-public class Counters
-{
-    public int Calls;
-    public int Successes;
-}
-
-public class MockHttpMessageHandler : HttpClientHandler
-{
-    private readonly Counters _counters;
-    private Exception? _exception;
-
-    public MockHttpMessageHandler(Counters counters)
-    {
-        _counters = counters;
-    }
-
-    public Exception? Exception => _exception;
-
-    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-    {
-        Interlocked.Increment(ref _counters.Calls);
-        try
-        {
-            var response = await base.SendAsync(request, cancellationToken);
-            if (response.IsSuccessStatusCode)
-            {
-                Interlocked.Increment(ref _counters.Successes);
-            }
-
-            return response;
-        }
-        catch (Exception ex)
-        {
-            _exception = ex;
-            throw;
-        }
     }
 }

--- a/src/Amplitude.Net.Tests/Counters.cs
+++ b/src/Amplitude.Net.Tests/Counters.cs
@@ -1,0 +1,7 @@
+namespace Amplitude.Net.Tests;
+
+public class Counters
+{
+    public int Calls;
+    public int Successes;
+}

--- a/src/Amplitude.Net.Tests/MockHttpMessageHandler.cs
+++ b/src/Amplitude.Net.Tests/MockHttpMessageHandler.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Amplitude.Net.Tests;
+
+public class MockHttpMessageHandler : HttpClientHandler
+{
+    private readonly Counters _counters;
+    private Exception? _exception;
+
+    public MockHttpMessageHandler(Counters counters)
+    {
+        _counters = counters;
+    }
+
+    public Exception? Exception => _exception;
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        Interlocked.Increment(ref _counters.Calls);
+        try
+        {
+            var response = await base.SendAsync(request, cancellationToken);
+            if (response.IsSuccessStatusCode)
+            {
+                Interlocked.Increment(ref _counters.Successes);
+            }
+
+            return response;
+        }
+        catch (Exception ex)
+        {
+            _exception = ex;
+            throw;
+        }
+    }
+}

--- a/src/Amplitude.Net/Amplitude.cs
+++ b/src/Amplitude.Net/Amplitude.cs
@@ -16,9 +16,9 @@ public class Amplitude : IAmplitude
         _sender = sender;
     }
 
-    public IAmplitudeForTarget ForUserId(string userId)
+    public IAmplitudeForTarget ForUserId(string userId, string? deviceId = default)
     {
-        return new AmplitudeForUser(_logger, _sender, userId);
+        return new AmplitudeForUser(_logger, _sender, userId, deviceId);
     }
 
     public IAmplitudeForTarget ForDeviceId(string deviceId)

--- a/src/Amplitude.Net/AmplitudeForDevice.cs
+++ b/src/Amplitude.Net/AmplitudeForDevice.cs
@@ -4,7 +4,7 @@ namespace Amplitude.Net;
 
 public class AmplitudeForDevice: AmplitudeFor
 {
-    public AmplitudeForDevice(ILogger logger, IAmplitudeSender amplitudeSender, string deviceId) : base(logger, amplitudeSender, new KeyValuePair<string, object>("device_id", deviceId))
+    public AmplitudeForDevice(ILogger logger, IAmplitudeSender amplitudeSender, string deviceId) : base(logger, amplitudeSender, new [] {new KeyValuePair<string, object?>("device_id", deviceId) })
     {
     }
 }

--- a/src/Amplitude.Net/AmplitudeForUser.cs
+++ b/src/Amplitude.Net/AmplitudeForUser.cs
@@ -4,7 +4,9 @@ namespace Amplitude.Net;
 
 public class AmplitudeForUser: AmplitudeFor
 {
-    public AmplitudeForUser(ILogger logger, IAmplitudeSender amplitudeSender, string userId) : base(logger, amplitudeSender, new KeyValuePair<string, object>("user_id", userId))
+    public AmplitudeForUser(ILogger logger, IAmplitudeSender amplitudeSender, string userId, string? deviceId) : base(logger, amplitudeSender, 
+        new [] {new KeyValuePair<string, object?>("user_id", userId), new KeyValuePair<string, object?>("device_id", deviceId)}
+        )
     {
     }
 }

--- a/src/Amplitude.Net/AsyncAmplitudeSender.cs
+++ b/src/Amplitude.Net/AsyncAmplitudeSender.cs
@@ -267,9 +267,17 @@ public class AsyncAmplitudeSender : IAmplitudeSender,
         _identifyTimer.Dispose();
         _identifySemaphore.Dispose();
         
+        _eventTimer.Dispose();
+        _eventSemaphore.Dispose();
+        
         while (!_identifyQueue.IsEmpty)
         {
             Task.WaitAll(ProcessIdentifyQueue());
+        }
+
+        while (!_eventQueue.IsEmpty)
+        {
+            Task.WaitAll(ProcessEventQueue());
         }
     }
 #else
@@ -277,10 +285,18 @@ public class AsyncAmplitudeSender : IAmplitudeSender,
     {
         _identifyTimer.Dispose();
         _identifySemaphore.Dispose();
+        
+        _eventTimer.Dispose();
+        _eventSemaphore.Dispose();
 
         while (!_identifyQueue.IsEmpty)
         {
             await ProcessIdentifyQueue();
+        }
+        
+        while (!_eventQueue.IsEmpty)
+        {
+            await ProcessEventQueue();
         }
     }
 #endif

--- a/src/Amplitude.Net/AsyncAmplitudeSender.cs
+++ b/src/Amplitude.Net/AsyncAmplitudeSender.cs
@@ -83,7 +83,7 @@ public class AsyncAmplitudeSender : IAmplitudeSender,
     private async Task ProcessIdentifyQueue()
     {
         if (_identifyQueue.IsEmpty) return;
-        await _identifySemaphore.WaitAsync();
+        if (!await _identifySemaphore.WaitAsync(TimeSpan.FromMilliseconds(50))) return;
         try
         {
             const int max = 20;
@@ -115,7 +115,8 @@ public class AsyncAmplitudeSender : IAmplitudeSender,
     private async Task ProcessEventQueue()
     {
         if (_eventQueue.IsEmpty) return;
-        await _eventSemaphore.WaitAsync();
+        if (!await _eventSemaphore.WaitAsync(TimeSpan.FromMilliseconds(50))) return;
+            
         try
         {
             const int max = 20;

--- a/src/Amplitude.Net/IAmplitude.cs
+++ b/src/Amplitude.Net/IAmplitude.cs
@@ -2,6 +2,6 @@
 
 public interface IAmplitude
 {
-    IAmplitudeForTarget ForUserId(string userId);
+    IAmplitudeForTarget ForUserId(string userId, string? deviceId = default);
     IAmplitudeForTarget ForDeviceId(string deviceId);
 }

--- a/src/Amplitude.Net/IAmplitudeSender.cs
+++ b/src/Amplitude.Net/IAmplitudeSender.cs
@@ -9,6 +9,6 @@ using ReturnType = ValueTask;
 
 public interface IAmplitudeSender
 {
-    ReturnType Identify(IDictionary<string, object?> payload, ILogger logger);
-    ReturnType Event(IDictionary<string, object?> payload, ILogger logger);
+    ReturnType Identify(IDictionary<string, object?> payload);
+    ReturnType Event(IDictionary<string, object?> payload);
 }


### PR DESCRIPTION
Changes the sender to deliver identify or events requests as batches.

Event queue and identify queue split out with separate poll timers.